### PR TITLE
Update typing rewrites for typing_extensions 4.6.0+

### DIFF
--- a/reorder_python_imports.py
+++ b/reorder_python_imports.py
@@ -420,8 +420,8 @@ REMOVALS[(3, 7)].add('from __future__ import generator_stop')
 # GENERATED VIA generate-typing-rewrite-info
 # Using:
 #     flake8-typing-imports==1.14.0
-#     mypy-extensions==0.4.3
-#     typing-extensions==4.4.0
+#     mypy-extensions==1.0.0
+#     typing-extensions==4.6.3
 REPLACES[(3, 6)].update((
     'typing_extensions=typing:AsyncIterable',
     'typing_extensions=typing:AsyncIterator',
@@ -430,7 +430,6 @@ REPLACES[(3, 6)].update((
     'typing_extensions=typing:ContextManager',
     'typing_extensions=typing:Coroutine',
     'typing_extensions=typing:DefaultDict',
-    'typing_extensions=typing:NewType',
     'typing_extensions=typing:TYPE_CHECKING',
     'typing_extensions=typing:Text',
     'typing_extensions=typing:Type',
@@ -447,9 +446,7 @@ REPLACES[(3, 7)].update((
 REPLACES[(3, 8)].update((
     'mypy_extensions=typing:TypedDict',
     'typing_extensions=typing:Final',
-    'typing_extensions=typing:Literal',
     'typing_extensions=typing:OrderedDict',
-    'typing_extensions=typing:Protocol',
     'typing_extensions=typing:SupportsIndex',
     'typing_extensions=typing:runtime_checkable',
 ))
@@ -459,6 +456,8 @@ REPLACES[(3, 9)].update((
 ))
 REPLACES[(3, 10)].update((
     'typing_extensions=typing:Concatenate',
+    'typing_extensions=typing:Literal',
+    'typing_extensions=typing:NewType',
     'typing_extensions=typing:ParamSpecArgs',
     'typing_extensions=typing:ParamSpecKwargs',
     'typing_extensions=typing:TypeAlias',
@@ -470,17 +469,13 @@ REPLACES[(3, 10)].update((
 REPLACES[(3, 11)].update((
     'typing_extensions=typing:Any',
     'typing_extensions=typing:LiteralString',
-    'typing_extensions=typing:NamedTuple',
     'typing_extensions=typing:Never',
     'typing_extensions=typing:NotRequired',
     'typing_extensions=typing:Required',
     'typing_extensions=typing:Self',
-    'typing_extensions=typing:TypedDict',
-    'typing_extensions=typing:Unpack',
     'typing_extensions=typing:assert_never',
     'typing_extensions=typing:assert_type',
     'typing_extensions=typing:clear_overloads',
-    'typing_extensions=typing:dataclass_transform',
     'typing_extensions=typing:final',
     'typing_extensions=typing:get_overloads',
     'typing_extensions=typing:overload',

--- a/testing/generate-typing-rewrite-info
+++ b/testing/generate-typing-rewrite-info
@@ -16,23 +16,40 @@ else:
 
 
 # --- typing_extensions notes ---
-# https://github.com/python/typing_extensions#other-notes-and-limitations
+# https://typing-extensions.readthedocs.io/en/latest/#
 # - Starting with Python 3.9, get_type_hints() has the include_extra parameter
 # - get_origin and get_args lack support for Annotated in Python 3.8
 #   and lack support for ParamSpecArgs and ParamSpecKwargs in 3.9.
-# - Starting with 3.11, NamedTuple and TypedDict can inherit from Generic
+# - Literal had several bugs in Python 3.8 and 3.9,
+#   which were fixed in Python 3.10.
+#   typing_extensions backports the bugfixes to earlier versions.
+# - NewType was reimplemented as a class rather than a function in Python 3.10,
+#   meaning newtypes are pickleable on 3.10+; typing_extensions backports this.
 # - @final was changed in Python 3.11 to set the .__final__ attribute
 # - @overload was changed in Python 3.11 to make function overloads
 #   introspectable at runtime.
 # - Any was change in Python 3.11 so it can be used as a base class
-# - Considered for Python 3.12
-#   - PEP 695 infer_variance parameter for TypeVar
-#   - PEP 696 default parameter for TypeVar, TypeVarTuple, and ParamSpec
+# - From 3.11, NamedTuple and TypedDict can inherit from Generic;
+#   from 3.12 onwards, the __orig_bases__ attribute
+#   is properly set on NamedTuple and TypedDict classes
+# - The frozen_default parameter was added to dataclass_transform in py312
+# - isinstance() checks are 20x faster or more for runtime-checkable protocols
+#   on py312; typing_extensions backports the performance improvement
+# - The repr of Unpack was changed in py312 as part of PEP 692;
+#   typing_extensions backports this
+# - Python 3.12 adds the PEP 695 infer_variance parameter for TypeVar.
+#   The PEP 696 default parameter for TypeVar, TypeVarTuple, and ParamSpec
+#   is under consideration for Python 3.13.
 CUSTOM_TYPING_EXT_SYMBOLS = {
     (3, 9): {'get_type_hints'},
-    (3, 10): {'get_origin', 'get_args'},
-    (3, 11): {'Any', 'NamedTuple', 'TypedDict', 'final', 'overload'},
-    (3, 12): {'ParamSpec', 'TypeVar', 'TypeVarTuple'},
+    (3, 10): {'get_origin', 'get_args', 'Literal', 'NewType'},
+    (3, 11): {'Any', 'final', 'overload'},
+    (3, 12): {
+        'Protocol', 'SupportsInt', 'SupportsFloat', 'SupportsComplex',
+        'SupportsBytes', 'SupportsAbs', 'SupportsRound', 'NamedTuple',
+        'TypedDict', 'Unpack', 'dataclass_transform',
+    },
+    (3, 13): {'TypeVar', 'TypeVarTuple', 'ParamSpec'},
 }
 
 


### PR DESCRIPTION
As discussed in https://github.com/asottile/pyupgrade/issues/842.

typing_extensions 4.6.0 backported many bugfixes and enhancements from newer Python versions:
- Several bugfixes for `Literal` that were fixed in 3.10 but no earlier
- Pickleable newtypes from 3.10
- NamedTuples and TypedDicts with correct `__orig_bases__` attributes from 3.12
- Much more performant runtime-checkable protocols from 3.12
- A better repr for `Unpack`, from 3.12
- A new parameter for `dataclass_transform`, from 3.12