### PR TITLE
Keep whitespace before imports

### DIFF
--- a/reorder_python_imports.py
+++ b/reorder_python_imports.py
@@ -94,12 +94,12 @@ def partition_source(src: str) -> tuple[str, list[str], str, str]:
             pre_import = False
             chunks.append((CodeType.IMPORT, s))
         elif token_type is Tok.NEWLINE:
-            if s.isspace():
-                tp = CodeType.NON_CODE
-            elif pre_import:
+            if pre_import:
                 tp = CodeType.PRE_IMPORT_CODE
+            elif s.isspace():
+                tp = CodeType.NON_CODE
             else:
-                tp = CodeType.CODE
+               tp = CodeType.CODE
 
             chunks.append((tp, s))
         elif pre_import and token_type is Tok.STRING:

--- a/reorder_python_imports.py
+++ b/reorder_python_imports.py
@@ -99,7 +99,7 @@ def partition_source(src: str) -> tuple[str, list[str], str, str]:
             elif s.isspace():
                 tp = CodeType.NON_CODE
             else:
-               tp = CodeType.CODE
+                tp = CodeType.CODE
 
             chunks.append((tp, s))
         elif pre_import and token_type is Tok.STRING:


### PR DESCRIPTION
Fixes #366

Makes reorder-python-imports compatible again with newer black and ruff versions. I'm quite indifferent to the actual formatting change and I'm not happy with the [attitude of the black maintainers](https://github.com/psf/black/issues/4175#issuecomment-1912243764) . But on the other hand, I don't see a point in fighting windmills and after ruff picked up the formatting change, I don't see a chance to go back.