### PR TITLE
Update typing rewrites for typing_extensions 4.12.0+

### DIFF
--- a/reorder_python_imports.py
+++ b/reorder_python_imports.py
@@ -421,7 +421,7 @@ REMOVALS[(3, 7)].add('from __future__ import generator_stop')
 # Using:
 #     flake8-typing-imports==1.15.0
 #     mypy-extensions==1.0.0
-#     typing-extensions==4.8.0
+#     typing-extensions==4.12.1
 REPLACES[(3, 6)].update((
     'typing_extensions=typing:AbstractSet',
     'typing_extensions=typing:AnyStr',
@@ -433,12 +433,10 @@ REPLACES[(3, 6)].update((
     'typing_extensions=typing:ClassVar',
     'typing_extensions=typing:Collection',
     'typing_extensions=typing:Container',
-    'typing_extensions=typing:ContextManager',
     'typing_extensions=typing:Coroutine',
     'typing_extensions=typing:DefaultDict',
     'typing_extensions=typing:Dict',
     'typing_extensions=typing:FrozenSet',
-    'typing_extensions=typing:Generator',
     'typing_extensions=typing:Generic',
     'typing_extensions=typing:Hashable',
     'typing_extensions=typing:IO',
@@ -472,8 +470,6 @@ REPLACES[(3, 6)].update((
 ))
 REPLACES[(3, 7)].update((
     'mypy_extensions=typing:NoReturn',
-    'typing_extensions=typing:AsyncContextManager',
-    'typing_extensions=typing:AsyncGenerator',
     'typing_extensions=typing:ChainMap',
     'typing_extensions=typing:Counter',
     'typing_extensions=typing:Deque',
@@ -484,8 +480,6 @@ REPLACES[(3, 8)].update((
     'mypy_extensions=typing:TypedDict',
     'typing_extensions=typing:Final',
     'typing_extensions=typing:OrderedDict',
-    'typing_extensions=typing:SupportsIndex',
-    'typing_extensions=typing:runtime_checkable',
 ))
 REPLACES[(3, 9)].update((
     'typing_extensions=typing:Annotated',
@@ -520,15 +514,14 @@ REPLACES[(3, 11)].update((
 ))
 REPLACES[(3, 12)].update((
     'typing_extensions=typing:NamedTuple',
-    'typing_extensions=typing:Protocol',
     'typing_extensions=typing:SupportsAbs',
     'typing_extensions=typing:SupportsBytes',
     'typing_extensions=typing:SupportsComplex',
     'typing_extensions=typing:SupportsFloat',
+    'typing_extensions=typing:SupportsIndex',
     'typing_extensions=typing:SupportsInt',
     'typing_extensions=typing:SupportsRound',
     'typing_extensions=typing:TypeAliasType',
-    'typing_extensions=typing:TypedDict',
     'typing_extensions=typing:Unpack',
     'typing_extensions=typing:dataclass_transform',
     'typing_extensions=typing:override',

--- a/testing/generate-typing-rewrite-info
+++ b/testing/generate-typing-rewrite-info
@@ -27,25 +27,35 @@ import typing_extensions
 # - Any was change in Python 3.11 so it can be used as a base class
 # - From 3.11, NamedTuple and TypedDict can inherit from Generic;
 #   from 3.12 onwards, the __orig_bases__ attribute
-#   is properly set on NamedTuple and TypedDict classes
+#   is properly set on NamedTuple and TypedDict classes.
+#   From 3.13 onwards, TypedDict fields can be marked as `ReadOnly`.
 # - The frozen_default parameter was added to dataclass_transform in py312
 # - isinstance() checks are 20x faster or more for runtime-checkable protocols
-#   on py312; typing_extensions backports the performance improvement
+#   on py312; typing_extensions backports the performance improvement.
+#   It also backports several bugfixes from early py312 patch releases.
 # - The repr of Unpack was changed in py312 as part of PEP 692;
 #   typing_extensions backports this
 # - Python 3.12 adds the PEP 695 infer_variance parameter for TypeVar.
-#   The PEP 696 default parameter for TypeVar, TypeVarTuple, and ParamSpec
-#   is under consideration for Python 3.13.
+# - The PEP 696 default parameter for TypeVar, TypeVarTuple, and ParamSpec
+#   has been added in Python 3.13.
+# - (Async)Generator now has a default value for all type parameters except
+#   the first one on py313+, and (Async)ContextManager now has an optional
+#   second parameter with a default value; typing_extensions backports these
+#   changes.
 CUSTOM_TYPING_EXT_SYMBOLS = {
     (3, 9): {'get_type_hints'},
     (3, 10): {'get_origin', 'get_args', 'Literal', 'NewType'},
     (3, 11): {'Any', 'final', 'overload'},
     (3, 12): {
-        'Protocol', 'SupportsInt', 'SupportsFloat', 'SupportsComplex',
+        'SupportsInt', 'SupportsFloat', 'SupportsComplex',
         'SupportsBytes', 'SupportsAbs', 'SupportsRound', 'NamedTuple',
-        'TypedDict', 'Unpack', 'dataclass_transform',
+        'Unpack', 'dataclass_transform', 'SupportsIndex',
     },
-    (3, 13): {'TypeVar', 'TypeVarTuple', 'ParamSpec'},
+    (3, 13): {
+        'AsyncContextManager', 'ContextManager', 'AsyncGenerator', 'Generator',
+        'TypeVar', 'TypeVarTuple', 'ParamSpec', 'TypedDict', 'Protocol',
+        'runtime_checkable',
+    },
 }
 
 


### PR DESCRIPTION
This adjusts a few import rewrites so that pyupgrade doesn't overly eagerly rewrite some imports where `typing_extensions` has backported some new features or bugfixes from newer Python versions.

- `(Async)Generator`, `(Async)ContextManager` -- these have both had recent changes as part of the PEP-696 implementation in CPython. `(Async)Generator` now has default values for some type parameters; `(Async)ContextManager` now has an optional second type parameter.
- `isinstance()` checks against `SupportsIndex` became much faster in Python 3.12; `typing_extensions` backports those changes
- It no longer works to use `typing.runtime_checkable` with `typing_extensions.Protocol`; you'll get a nasty `AttributeError` at runtime. `typing_extensions` also backports some bugfixes for `Protocol` from the early py312 patch releases, so I changed these both so that they're only rewritten on py313+.
- `TypedDict` has a few changes in Python 3.13 for the PEP-705 implementation; `typing_extensions` backports those.