### PR TITLE
Rewrite `@deprecated` from `typing_extensions` to `warnings`

### DIFF
--- a/reorder_python_imports.py
+++ b/reorder_python_imports.py
@@ -420,8 +420,8 @@ REMOVALS[(3, 7)].add('from __future__ import generator_stop')
 # GENERATED VIA generate-typing-rewrite-info
 # Using:
 #     flake8-typing-imports==1.16.0
-#     mypy-extensions==1.0.0
-#     typing-extensions==4.12.2
+#     mypy-extensions==1.1.0
+#     typing-extensions==4.13.2
 REPLACES[(3, 6)].update((
     'typing_extensions=typing:AbstractSet',
     'typing_extensions=typing:AnyStr',
@@ -542,6 +542,7 @@ REPLACES[(3, 13)].update((
     'typing_extensions=typing:get_protocol_members',
     'typing_extensions=typing:is_protocol',
     'typing_extensions=typing:runtime_checkable',
+    'typing_extensions=warnings:deprecated',
 ))
 # END GENERATED
 

--- a/testing/generate-typing-rewrite-info
+++ b/testing/generate-typing-rewrite-info
@@ -65,7 +65,7 @@ def main() -> int:
     typing_extensions_version = version('typing_extensions')
 
     mypy_extensions_all = frozenset(
-        a for a in dir(mypy_extensions) if a != 'Any'
+        a for a in dir(mypy_extensions) if a not in {'Any', 'Dict'}
     )
     typing_extensions_all = frozenset(typing_extensions.__all__) - {
         sym for v in CUSTOM_TYPING_EXT_SYMBOLS.values() for sym in v
@@ -111,6 +111,12 @@ def main() -> int:
         }
     for v, attrs in CUSTOM_TYPING_EXT_SYMBOLS.items():
         replaces[v] |= {f'typing_extensions=typing:{s}' for s in attrs}
+
+    # NoReturn was removed from mypy_extensions
+    replaces[(3, 7)].add('mypy_extensions=typing:NoReturn')
+
+    # @deprecated was added to warnings in Python 3.13.
+    replaces[(3, 13)].add('typing_extensions=warnings:deprecated')
 
     print(f'# GENERATED VIA {os.path.basename(sys.argv[0])}')
     print('# Using:')


### PR DESCRIPTION
`@deprecated` can be imported [from the `warnings` module starting with Python 3.13](https://typing-extensions.readthedocs.io/en/latest/#typing_extensions.deprecated). This PR adds it to the `typing_extension` rewrites.

```
% echo 'from typing_extensions import deprecated' | \
    python reorder_python_imports.py --py313-plus -

from warnings import deprecated
```